### PR TITLE
Fix python_version format

### DIFF
--- a/honeydb.json
+++ b/honeydb.json
@@ -16,10 +16,7 @@
     "main_module": "honeydb_connector.py",
     "min_phantom_version": "4.9.39220",
     "app_wizard_version": "1.0.0",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_version": [
         "cloud, api/v1 tested on 1st July, 2021"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)